### PR TITLE
Add display SENSOR_INFO_TIMESTAMP_SOURCE info

### DIFF
--- a/android_app/app/src/main/java/se/lth/math/videoimucapture/Camera2Proxy.java
+++ b/android_app/app/src/main/java/se/lth/math/videoimucapture/Camera2Proxy.java
@@ -341,7 +341,7 @@ public class Camera2Proxy {
                     }
                     Integer timestamp_source = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_TIMESTAMP_SOURCE);
                     String timestamp_source_str = "UNKNOWN";
-                    if (timestamp_source == 1) {
+                    if (timestamp_source == CameraMetadata.SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME) {
                         timestamp_source_str = "REALTIME";
                     }
                     ((CameraCaptureActivity) mActivity).getmCameraCaptureFragment()

--- a/android_app/app/src/main/java/se/lth/math/videoimucapture/Camera2Proxy.java
+++ b/android_app/app/src/main/java/se/lth/math/videoimucapture/Camera2Proxy.java
@@ -339,8 +339,13 @@ public class Camera2Proxy {
                     if (mRecordingMetadata) {
                         writeCaptureData(result, focal_length_pix);
                     }
+                    Integer timestamp_source = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_TIMESTAMP_SOURCE);
+                    String timestamp_source_str = "UNKNOWN";
+                    if (timestamp_source == 1) {
+                        timestamp_source_str = "REALTIME";
+                    }
                     ((CameraCaptureActivity) mActivity).getmCameraCaptureFragment()
-                            .updateCaptureResultPanel(focal_length_pix, exposureTimeNs);
+                            .updateCaptureResultPanel(focal_length_pix, exposureTimeNs, timestamp_source_str);
                 }
 
                 @Override

--- a/android_app/app/src/main/java/se/lth/math/videoimucapture/CameraCaptureFragment.java
+++ b/android_app/app/src/main/java/se/lth/math/videoimucapture/CameraCaptureFragment.java
@@ -336,19 +336,19 @@ public class CameraCaptureFragment extends Fragment
 
     public void updateCaptureResultPanel(
             final Float fl,
-            final Long exposureTimeNs) {
+            final Long exposureTimeNs,
+            final String timestampSourceStr) {
         final String sfl = String.format(Locale.getDefault(), "FL: %.3f", fl);
         final String sexpotime =
                 exposureTimeNs == null ?
                         "null ms" :
                         String.format(Locale.getDefault(), "Exp: %.2f ms",
                                 exposureTimeNs / 1000000.0);
-        final String imuHz = String.format(Locale.getDefault(),  "IMU: %.0fHz",
+        final String imuHz = String.format(Locale.getDefault(), "IMU: %.0fHz",
                 getmImuManager().getSensorFrequency());
-
         getActivity().runOnUiThread(() -> {
             if (mCaptureResultText != null) {
-                mCaptureResultText.setText("|" + sfl + "|" + sexpotime + "|" + imuHz + "|");
+                mCaptureResultText.setText("|" + sfl + "|" + sexpotime + "|" + imuHz + "|" + timestampSourceStr + "|" );
             }
         });
     }


### PR DESCRIPTION
SENSOR_INFO_TIMESTAMP_SOURCE
Added in [API level 21](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels)

public static final [Key](https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics.Key)<[Integer](https://developer.android.com/reference/java/lang/Integer)> SENSOR_INFO_TIMESTAMP_SOURCE
The time base source for sensor capture start timestamps.

The timestamps provided for captures are always in nanoseconds and monotonic, but may not based on a time source that can be compared to other system time sources.

This characteristic defines the source for the timestamps, and therefore whether they can be compared against other system time sources/timestamps.

Possible values:

[UNKNOWN](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#SENSOR_INFO_TIMESTAMP_SOURCE_UNKNOWN)
[REALTIME](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME)
This key is available on all devices.

See also:

[CameraMetadata.SENSOR_INFO_TIMESTAMP_SOURCE_UNKNOWN](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#SENSOR_INFO_TIMESTAMP_SOURCE_UNKNOWN)
[CameraMetadata.SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#SENSOR_INFO_TIMESTAMP_SOURCE_REALTIME)